### PR TITLE
Corrected the `for` attributes for compatibility with React

### DIFF
--- a/client/public/js/components/EventCreate.js
+++ b/client/public/js/components/EventCreate.js
@@ -33,11 +33,11 @@ var EventCreate = React.createClass({
       <div className="event-create">
         <form className="eventCreateForm" onSubmit={this._save}>
           <div className="form-group">
-            <label for="name">Event name</label>
+            <label htmlFor="name">Event name</label>
             <input className="form-control inputBox" type="text" name="name" id="name" placeholder="Event name" value={this.state.name} onChange={this._onChange} />
           </div>
           <div className="form-group">
-            <label for="location">Event location</label>
+            <label htmlFor="location">Event location</label>
             <input className="form-control inputBox" type="text" name="location" id="location" placeholder="Event location" value={this.state.location} onChange={this._onChange} />
           </div>
           <button type="submit" className="btn btn-default">Submit</button>


### PR DESCRIPTION
In React, `htmlFor` should be used instead of `for` to match the DOM API specification.
