### PR TITLE
input fields are cleared upon submission

### DIFF
--- a/client/public/js/components/ObservationList/ObservationCreate.js
+++ b/client/public/js/components/ObservationList/ObservationCreate.js
@@ -77,6 +77,7 @@ var ObservationCreate = React.createClass({
       rawImage: this.state.rawImage
     };
     ObservationActions.create(newObservation);
+    this._onCreate();
   },
 
   // Update the current state with the new values in the input fields


### PR DESCRIPTION
seems like the bug is caused by the difference in states when polling. quick fix was to call the this._onCreate just to clear the fields by resetting state. thoughts?
